### PR TITLE
Fix typo in project year

### DIFF
--- a/deepsynth.html
+++ b/deepsynth.html
@@ -5,7 +5,7 @@
 
 <b>Principal investigator:</b> Nathana&euml;l Fijalkow
 <br/>
-<b>Duration:</b> 2019 -- 2012 (3 years)
+<b>Duration:</b> 2019 -- 2022 (3 years)
 <br/>
 <b>Budget:</b> 180k &euro; plus a two-year postdoc
 <br/>


### PR DESCRIPTION
Dis-moi si tu préfères que je change le « 3 years » en « –7 years » à la place.